### PR TITLE
Prepare package for npm publish as scoped fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "redux-persist",
       "version": "0.0.1",
       "license": "MIT",
-      "dependencies": {
-        "redux-persist": "^6.0.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.15.0",
         "@babel/preset-env": "^7.15.0",
@@ -1544,6 +1541,7 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
       "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -7193,6 +7191,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
       "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -7204,15 +7203,6 @@
       "dev": true,
       "dependencies": {
         "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "node_modules/redux-persist": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
-      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": ">4.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -7236,7 +7226,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-persist",
+  "name": "@mdemichele/redux-persist",
   "version": "0.0.1",
   "description": "persist and rehydrate redux stores",
   "type": "module",
@@ -8,7 +8,6 @@
   "types": "lib/index.d.ts",
   "repository": "mdemichele/redux-persist",
   "files": [
-    "src",
     "es",
     "lib",
     "dist",
@@ -78,8 +77,5 @@
   },
   "peerDependencies": {
     "redux": ">4.0.0"
-  },
-  "dependencies": {
-    "redux-persist": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Rename package from `redux-persist` to `@mdemichele/redux-persist` to avoid naming conflict with the original abandoned package
- Remove circular self-dependency (`redux-persist` listed as its own runtime dependency)
- Remove `src/` from the published `files` array — compiled outputs (`lib/`, `es/`, `dist/`) are sufficient for consumers

## Test plan

- [ ] Verify `npm publish --access public` succeeds after merging (requires `npm login`)
- [ ] Confirm package installs correctly from npm as `@mdemichele/redux-persist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)