### PR TITLE
Fix repository field format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "lib/index.d.ts",
-  "repository": "mdemichele/redux-persist",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdemichele/redux-persist.git"
+  },
   "files": [
     "es",
     "lib",


### PR DESCRIPTION
## Summary

- Normalizes the `repository` field from a shorthand string to a proper object with `type` and `url`
- Syncs the fix that npm auto-applied during the 0.0.1 publish back into source

🤖 Generated with [Claude Code](https://claude.com/claude-code)