### PR TITLE
Chore: update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "ava": "ava",
     "build": "npm run build:commonjs && npm run build:es && npm run build:umd",
-    "build:commonjs": "tsc --module commonjs --outDir lib",
+    "build:commonjs": "tsc --module commonjs --moduleResolution node --ignoreDeprecations 6.0 --outDir lib",
     "build:es": "tsc --module es2015 --outDir es",
     "build:umd": "rollup -c",
     "clean": "rimraf dist && rimraf es && rimraf lib",
@@ -51,14 +51,15 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "^7.15.0",
+    "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.15.0",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@types/react": "^17.0.16",
+    "@types/node": "^24.13.2",
+    "@types/react": "^19.2.17",
     "@types/redux-mock-store": "^1.0.3",
     "@types/sinon": "^10.0.2",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
@@ -76,7 +77,7 @@
     "sinon": "^11.1.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "redux": ">4.0.0"

--- a/src/persistReducer.ts
+++ b/src/persistReducer.ts
@@ -16,6 +16,7 @@ import type {
   PersistConfig,
   PersistState,
   Persistoid,
+  KeyAccessState,
 } from './types'
 
 import autoMergeLevel1 from './stateReconciler/autoMergeLevel1'
@@ -30,7 +31,7 @@ const DEFAULT_TIMEOUT = 5000
   - persisting a reducer which has nested _persist
   - handling actions that fire before reydrate is called
 */
-export default function persistReducer<S, A extends Action>(
+export default function persistReducer<S extends KeyAccessState, A extends Action>(
   config: PersistConfig<S>,
   baseReducer: Reducer<S, A>
 ): Reducer<S & PersistPartial, AnyAction> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "es2015",                             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                                   /* Specify library files to be included in the compilation. */
+    "module": "es2015",                              /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["ES2018", "DOM"],                        /* Include ES2018 (covers Promise.finally) and DOM type definitions. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
@@ -15,7 +15,7 @@
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
     "outDir": "./dist",                             /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./src",                              /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */
@@ -44,12 +44,12 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",                   /* Specify module resolution strategy: 'bundler' for bundler tools (Rollup/Webpack/Vite). Compatible with 'es2015'+ module output. */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    "types": ["node"],                               /* Include @types/node globals (process, Buffer, etc.) needed for process.env.NODE_ENV checks. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
 Upgrade TypeScript from v4 to v6
  
  Updates TypeScript to v6 and resolves all resulting build errors.

  Package changes:
  - Bumps typescript from ^4.3.5 to ^6.0.3
  - Bumps @babel/core and @types/react to latest                                                                                                                                        
  - Adds @types/node to support process.env.NODE_ENV type checking

  Build config (tsconfig.json):
  - Sets rootDir: "./src" explicitly (now required by TS6)
  - Changes module from commonjs to es2015 to be compatible with moduleResolution: "bundler"
  - Changes moduleResolution from node (deprecated) to bundler, which is appropriate for this Rollup-compiled library
  - Adds lib: ["ES2018", "DOM"] to include Promise.finally and DOM types 
  - Adds types: ["node"] to expose process global from @types/node 
  - Updates build:commonjs script to pass --moduleResolution node --ignoreDeprecations 6.0 since CJS output requires the legacy node resolver (no modern equivalent exists for module: commonjs)

  Source fix (persistReducer.ts):
  - Adds S extends KeyAccessState constraint to persistReducer<S> to satisfy stricter generic type checking in TS6