### PR TITLE
fix: rehydrate immediately when storage is empty on first run

### DIFF
--- a/src/persistReducer.ts
+++ b/src/persistReducer.ts
@@ -142,6 +142,8 @@ export default function persistReducer<S extends KeyAccessState, A extends Actio
                 _rehydrate(undefined, migrateErr)
               }
             )
+          } else {
+            _rehydrate(undefined)
           }
         },
         err => {

--- a/tests/persistReducer.spec.ts
+++ b/tests/persistReducer.spec.ts
@@ -37,3 +37,12 @@ test('persistedReducer calls register and rehydrate after PERSIST', async (t) =>
   t.is(register.callCount, 1)
   t.is(rehydrate.callCount, 1)
 })
+
+test('persistedReducer rehydrates immediately when storage is empty', async (t) => {
+  const persistedReducer = persistReducer(config, reducer)
+  const register = sinon.spy()
+  const rehydrate = sinon.spy()
+  persistedReducer({}, { type: PERSIST, register, rehydrate })
+  await sleep(50)
+  t.is(rehydrate.callCount, 1)
+})


### PR DESCRIPTION
## Summary

- Fixes Bug 1 from `docs/known-issues.md`: on a first run (or after clearing storage), `getStoredState` resolves with `undefined`, but the success callback had no `else` branch and never called `_rehydrate`. This caused `PersistGate` to hang for the full 5-second timeout before bootstrapping.
- Added `else { _rehydrate(undefined) }` in `src/persistReducer.ts` so a clean no-stored-state path bootstraps immediately.
- Added a regression test in `tests/persistReducer.spec.ts` that asserts `rehydrate` is called within 50ms on empty storage, rather than waiting for the timeout.

## Root cause

In `src/persistReducer.ts`, the `getStoredState` success callback only handled the case where state existed:

```ts
// Before
getStoredState(config).then(
  restoredState => {
    if (restoredState) {
      // migrate and rehydrate...
    }
    // ← no else: _rehydrate never called when storage is empty
  },
  ...
)
```

Without the `else` branch, `_rehydrate` was never called on a first run, so `bootstrapped` stayed `false` and `PersistGate` blocked rendering until the 5-second timeout fired.

## Changes

| File | Change |
|------|--------|
| `src/persistReducer.ts` | Added `else { _rehydrate(undefined) }` to the `getStoredState` success callback |
| `tests/persistReducer.spec.ts` | Added regression test verifying immediate rehydration on empty storage |

---

## Pre-merge checklist

> This checklist should be completed by the author and reviewed by a maintainer before merging any PR into `master`.

### Author
- [ ] Changes are scoped to a single concern (bug fix, feature, refactor, docs, etc.)
- [ ] All existing tests pass locally (`npm test`)
- [ ] New tests are added for any new behavior or bug fix
- [ ] New tests are meaningful — they would have caught the bug or regression being addressed
- [ ] TypeScript compiles without errors (`npm run build`)
- [ ] No unrelated files are included in the commit (e.g. lock files modified before this branch)

### Reviewer
- [ ] The PR description clearly explains the problem and solution
- [ ] The fix is correct and handles edge cases
- [ ] Tests adequately cover the changed behavior
- [ ] No new technical debt is introduced without a corresponding issue or note
- [ ] `docs/known-issues.md` (or equivalent) is updated if this closes a tracked issue

### Before merging
- [ ] Branch is up to date with `master`
- [ ] PR has been approved by at least one maintainer
- [ ] If this closes a known issue, the issue is referenced (e.g. `Closes #N`) and removed from `known-issues.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)