### PR TITLE
fix: find() returns null instead of {} when no match found

### DIFF
--- a/tests/persistStore.spec.ts
+++ b/tests/persistStore.spec.ts
@@ -33,7 +33,7 @@ test('persistStore dispatches PERSIST action', t => {
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
   t.truthy(persistAction)
-  t.is('persist/PERSIST', persistAction.type)
+  t.is('persist/PERSIST', persistAction!.type)
 })
 
 test('register method adds a key to the registry', t => {
@@ -41,7 +41,8 @@ test('register method adds a key to the registry', t => {
   const persistor = persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
-  persistAction.register('canary')
+  t.truthy(persistAction)
+  persistAction!.register('canary')
   t.deepEqual(persistor.getState().registry, ['canary'])
 })
 
@@ -50,7 +51,8 @@ test('rehydrate method fires with the expected shape', t => {
   persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  t.truthy(persistAction)
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   const rehydrateAction = find(actions, { type: REHYDRATE })
   t.deepEqual(rehydrateAction, { type: REHYDRATE, key: 'canary', payload: { foo: 'bar' }, err: null })
 })
@@ -60,13 +62,14 @@ test('rehydrate method removes provided key from registry', t => {
   const persistor = persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
+  t.truthy(persistAction)
 
   // register canary
-  persistAction.register('canary')
+  persistAction!.register('canary')
   t.deepEqual(persistor.getState().registry, ['canary'])
 
   // rehydrate canary
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   t.deepEqual(persistor.getState().registry, [])
 })
 
@@ -75,14 +78,15 @@ test('rehydrate method removes exactly one of provided key from registry', t => 
   const persistor = persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
+  t.truthy(persistAction)
 
   // register canary twice
-  persistAction.register('canary')
-  persistAction.register('canary')
+  persistAction!.register('canary')
+  persistAction!.register('canary')
   t.deepEqual(persistor.getState().registry, ['canary', 'canary'])
 
   // rehydrate canary
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   t.deepEqual(persistor.getState().registry, ['canary'])
 })
 
@@ -91,10 +95,11 @@ test('once registry is cleared for first time, persistor is flagged as bootstrap
   const persistor = persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
+  t.truthy(persistAction)
 
-  persistAction.register('canary')
+  persistAction!.register('canary')
   t.false(persistor.getState().bootstrapped)
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   t.true(persistor.getState().bootstrapped)
 })
 
@@ -103,31 +108,33 @@ test('once persistor is flagged as bootstrapped, further registry changes do not
   const persistor = persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
+  t.truthy(persistAction)
 
-  persistAction.register('canary')
+  persistAction!.register('canary')
   t.false(persistor.getState().bootstrapped)
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   t.true(persistor.getState().bootstrapped)
 
   // add canary back, registry is updated but bootstrapped remains true
-  persistAction.register('canary')
+  persistAction!.register('canary')
   t.deepEqual(persistor.getState().registry, ['canary'])
   t.true(persistor.getState().bootstrapped)
 })
 
 test('persistStore calls bootstrapped callback (at most once) if provided', t => {
   const store = mockStore()
-  const bootstrappedCb = sinon.spy()  
+  const bootstrappedCb = sinon.spy()
   persistStore(store, {}, bootstrappedCb)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })
-  
-  persistAction.register('canary')
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  t.truthy(persistAction)
+
+  persistAction!.register('canary')
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   t.is(bootstrappedCb.callCount, 1)
 
   // further rehydrates do not trigger the cb
-  persistAction.register('canary')
-  persistAction.rehydrate('canary', { foo: 'bar' }, null)
+  persistAction!.register('canary')
+  persistAction!.rehydrate('canary', { foo: 'bar' }, null)
   t.is(bootstrappedCb.callCount, 1)
 })

--- a/tests/utils/find.ts
+++ b/tests/utils/find.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// @TODO: Need to specify what is the expected return value from this function. Is it Record<string, string> or can it also be null or undefind?
-export default (collection: Array<Record<string, any>>, predicate: Record<string, string>): any => {
-  let result = {}
+export default (collection: Array<Record<string, any>>, predicate: Record<string, string>): Record<string, any> | null => {
+  let result: Record<string, any> | null = null
   collection.forEach((value: any) => {
     if (value.type && value.type === predicate.type) {
       result = value


### PR DESCRIPTION
## Summary
- `find()` in `tests/utils/find.ts` previously returned `{}` (an empty object) when no matching action was found — since `{}` is always truthy, every `t.truthy(persistAction)` assertion in `persistStore.spec.ts` passed unconditionally, making those checks meaningless
- Fixed `find()` to return `null` on no match and updated its return type to `Record<string, any> | null`
- Added `t.truthy(persistAction)` guards in tests that were missing them, and added `!` non-null assertions where methods are called on the result so TypeScript is satisfied

Closes #11

## Test plan
- [ ] Run `npm test` — all 18 tests pass, 3 skipped (unchanged)
- [ ] Verify that a test would now correctly fail if `persistStore` stopped dispatching the `PERSIST` action

🤖 Generated with [Claude Code](https://claude.com/claude-code)