### PR TITLE
fix: resolve ESLint errors and warnings in tests folder

### DIFF
--- a/tests/flush.spec.ts
+++ b/tests/flush.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import test from 'ava'
 import { createStore } from 'redux'
 

--- a/tests/persistStore.spec.ts
+++ b/tests/persistStore.spec.ts
@@ -12,10 +12,10 @@ import { Middleware } from 'redux'
 import { Persistor } from '../src/types'
 
 const middleware: Middleware[] = []
-const mockStore: MockStoreCreator<unknown, {}> = configureStore(middleware)
+const mockStore: MockStoreCreator<unknown, object> = configureStore(middleware)
 
 test('persistStore returns a Persistor object', t => {
-  const store: MockStoreEnhanced<unknown, {}> = mockStore()
+  const store: MockStoreEnhanced<unknown, object> = mockStore()
   const persistor: Persistor = persistStore(store)
   t.is('object', typeof persistor)
   t.is('function', typeof persistor.pause)
@@ -28,7 +28,7 @@ test('persistStore returns a Persistor object', t => {
 })
 
 test('persistStore dispatches PERSIST action', t => {
-  const store: MockStoreEnhanced<unknown, {}> = mockStore()
+  const store: MockStoreEnhanced<unknown, object> = mockStore()
   persistStore(store)
   const actions = store.getActions()
   const persistAction = find(actions, { type: PERSIST })

--- a/tests/utils/brokenStorage.ts
+++ b/tests/utils/brokenStorage.ts
@@ -1,18 +1,15 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/ban-types */
 export default {
   getItem(): Promise<void> {
-    return new Promise((resolve: Function, reject: Function) => {})
+    return new Promise<void>(() => {})
   },
   setItem(): Promise<void> {
-    return new Promise((resolve: Function, reject: Function) => {})
+    return new Promise<void>(() => {})
   },
   removeItem(): Promise<void> {
-    return new Promise((resolve: Function, reject: Function) => {})
+    return new Promise<void>(() => {})
   },
   getAllKeys(): Promise<void> {
-    return new Promise((resolve: Function, reject: Function) => {})
+    return new Promise<void>(() => {})
   },
   keys: []
 }

--- a/tests/utils/find.ts
+++ b/tests/utils/find.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export default (collection: Array<Record<string, any>>, predicate: Record<string, string>): Record<string, any> | null => {
   let result: Record<string, any> | null = null
   collection.forEach((value: any) => {


### PR DESCRIPTION
## Summary

- Replace empty object type `{}` with `object` in `MockStoreCreator` and `MockStoreEnhanced` type params in `persistStore.spec.ts`
- Replace `Function` type with parameterless arrow functions `() => {}` in `brokenStorage.ts`, eliminating the need for `eslint-disable` suppression comments
- Remove stale `eslint-disable @typescript-eslint/no-explicit-any` directives from `flush.spec.ts` and `find.ts` (that rule is turned off in the ESLint config)
- Remove the defunct `@typescript-eslint/ban-types` disable comment from `brokenStorage.ts` (rule no longer exists in the current plugin version)

## Test plan

- [ ] Run `npx eslint ./tests` — should exit cleanly with no errors or warnings
- [ ] Run `npm test` — all existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)