### PR TITLE
Deprecate electron storage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ const persistConfig = {
 ## Storage Engines
 - **localStorage** `import storage from '@mdemichele/redux-persist/lib/storage'`
 - **sessionStorage** `import storageSession from '@mdemichele/redux-persist/lib/storage/session'`
-- **[electron storage](https://github.com/psperber/redux-persist-electron-storage)** Electron support via [electron store](https://github.com/sindresorhus/electron-store)
+- **[electron storage](https://github.com/psperber/redux-persist-electron-storage)** Electron support via [electron store](https://github.com/sindresorhus/electron-store) - [DEPRECATED]
 - **[redux-persist-cookie-storage](https://github.com/abersager/redux-persist-cookie-storage)** Cookie storage engine, works in browser and Node.js, for universal / isomorphic apps
 - **[redux-persist-expo-filesystem](https://github.com/t73liu/redux-persist-expo-filesystem)** react-native, similar to redux-persist-filesystem-storage but does not require linking or ejecting CRNA/Expo app. Only available if using Expo SDK (Expo, create-react-native-app, standalone).
 - **[redux-persist-expo-securestore](https://github.com/Cretezy/redux-persist-expo-securestore)** react-native, for sensitive information using Expo's SecureStore. Only available if using Expo SDK (Expo, create-react-native-app, standalone).


### PR DESCRIPTION
Mark electron storage as deprecated in README.