### PR TITLE
fix(persistReducer): add dev-mode validation for nested _persist and pre-rehydrate actions

### DIFF
--- a/src/persistReducer.ts
+++ b/src/persistReducer.ts
@@ -25,11 +25,7 @@ import purgeStoredState from './purgeStoredState'
 
 type PersistPartial = { _persist: PersistState } | any;
 const DEFAULT_TIMEOUT = 5000
-/*
-  @TODO add validation / handling for:
-  - persisting a reducer which has nested _persist
-  - handling actions that fire before reydrate is called
-*/
+
 export default function persistReducer<S extends KeyAccessState, A extends Action>(
   config: PersistConfig<S>,
   baseReducer: Reducer<S, A>
@@ -55,6 +51,7 @@ export default function persistReducer<S extends KeyAccessState, A extends Actio
   let _persistoid: Persistoid | null = null
   let _purge = false
   let _paused = true
+  let _warnedAboutNestedPersist = false
   const conditionalUpdate = (state: any) => {
     // update the persistoid only if we are rehydrated and not paused
     if (state._persist.rehydrated && _persistoid && !_paused)
@@ -65,6 +62,22 @@ export default function persistReducer<S extends KeyAccessState, A extends Actio
   return (state: any, action: any) => {
     const { _persist, ...rest } = state || {}
     const restState: S = rest
+
+    if (process.env.NODE_ENV !== 'production' && !_warnedAboutNestedPersist && restState) {
+      const nestedPersistKeys = Object.keys(restState).filter(
+        (key: string) =>
+          restState[key] &&
+          typeof restState[key] === 'object' &&
+          '_persist' in restState[key]
+      )
+      if (nestedPersistKeys.length > 0) {
+        _warnedAboutNestedPersist = true
+        console.error(
+          `redux-persist: nested _persist detected in reducer "${config.key}" for state keys: [${nestedPersistKeys.join(', ')}]. ` +
+          'This likely means you are nesting persistReducer. Ensure whitelist/blacklist is configured correctly to avoid persisting internal _persist metadata.'
+        )
+      }
+    }
 
     if (action.type === PERSIST) {
       let _sealed = false
@@ -194,6 +207,13 @@ export default function persistReducer<S extends KeyAccessState, A extends Actio
 
     // if we have not already handled PERSIST, straight passthrough
     if (!_persist) return baseReducer(state, action)
+
+    if (process.env.NODE_ENV !== 'production' && !_persist.rehydrated) {
+      console.warn(
+        `redux-persist: action "${action.type}" was dispatched for key "${config.key}" before rehydration completed. ` +
+        'This state change may be overwritten once rehydration finishes.'
+      )
+    }
 
     // run base reducer:
     // is state modified ? return original : return updated

--- a/tests/persistReducer.spec.ts
+++ b/tests/persistReducer.spec.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 
 import persistReducer from '../src/persistReducer'
 import createMemoryStorage from './utils/createMemoryStorage'
-import { PERSIST } from '../src/constants'
+import { PERSIST, REHYDRATE } from '../src/constants'
 import sleep from './utils/sleep'
 
 const reducer = () => ({})
@@ -45,4 +45,53 @@ test('persistedReducer rehydrates immediately when storage is empty', async (t) 
   persistedReducer({}, { type: PERSIST, register, rehydrate })
   await sleep(50)
   t.is(rehydrate.callCount, 1)
+})
+
+test('persistedReducer warns in dev when nested _persist is detected in state', (t) => {
+  const consoleError = sinon.stub(console, 'error')
+  const persistedReducer = persistReducer(config, reducer)
+  const stateWithNestedPersist = {
+    nested: { _persist: { version: 1, rehydrated: true }, value: 'foo' },
+  }
+  persistedReducer(stateWithNestedPersist as any, { type: 'SOME_ACTION' })
+  t.true(
+    consoleError.calledWithMatch(/nested _persist detected/)
+  )
+  consoleError.restore()
+})
+
+test('persistedReducer warns only once for nested _persist', (t) => {
+  const consoleError = sinon.stub(console, 'error')
+  const persistedReducer = persistReducer(config, reducer)
+  const stateWithNestedPersist = {
+    nested: { _persist: { version: 1, rehydrated: true }, value: 'foo' },
+  }
+  persistedReducer(stateWithNestedPersist as any, { type: 'ACTION_ONE' })
+  persistedReducer(stateWithNestedPersist as any, { type: 'ACTION_TWO' })
+  t.is(consoleError.callCount, 1)
+  consoleError.restore()
+})
+
+test('persistedReducer warns in dev when action fires before rehydration completes', (t) => {
+  const consoleWarn = sinon.stub(console, 'warn')
+  const persistedReducer = persistReducer(config, reducer)
+  const stateWithUnrehydratedPersist = {
+    _persist: { version: 1, rehydrated: false },
+  }
+  persistedReducer(stateWithUnrehydratedPersist as any, { type: 'SOME_ACTION' })
+  t.true(
+    consoleWarn.calledWithMatch(/was dispatched for key.*before rehydration completed/)
+  )
+  consoleWarn.restore()
+})
+
+test('persistedReducer does not warn when action fires after rehydration completes', (t) => {
+  const consoleWarn = sinon.stub(console, 'warn')
+  const persistedReducer = persistReducer(config, reducer)
+  const rehydratedState = {
+    _persist: { version: 1, rehydrated: true },
+  }
+  persistedReducer(rehydratedState as any, { type: 'SOME_ACTION' })
+  t.false(consoleWarn.called)
+  consoleWarn.restore()
 })


### PR DESCRIPTION
## Summary

Addresses the two edge cases noted in the @TODO at src/persistReducer.ts#L29 (tracked in #8).

- **Nested _persist detection**: emits a console.error (once per persistReducer instance via a _warnedAboutNestedPersist flag) when any value in restState contains a _persist key. This indicates a nested persistReducer that may inadvertently persist internal metadata unless whitelist/blacklist is configured correctly.
- **Pre-rehydrate action warning**: emits a console.warn when an action is dispatched after _persist is initialized but before rehydrated is true, alerting developers that the resulting state change may be overwritten once rehydration completes.

Both checks are wrapped in process.env.NODE_ENV !== 'production' guards and are covered by four new tests.

## Test plan

- [x] persistedReducer warns in dev when nested _persist is detected in state
- [x] persistedReducer warns only once for nested _persist
- [x] persistedReducer warns in dev when action fires before rehydration completes
- [x] persistedReducer does not warn when action fires after rehydration completes
- [x] All existing persistReducer tests still pass (npx ava tests/persistReducer.spec.ts)

Closes #8

Generated with [Claude Code](https://claude.com/claude-code)
