### PR TITLE
fix: un-skip createPersistor tests by switching to test.serial

### DIFF
--- a/tests/createPersistor.spec.ts
+++ b/tests/createPersistor.spec.ts
@@ -24,8 +24,7 @@ test.afterEach(() => {
     clock.restore()
 });
 
-// @NOTE these tests broke when updating sinon
-test.skip('it updates changed state', t => {
+test.serial('it updates changed state', t => {
     const { update } = createPersistoid(config)
     update({ a: 1 })
     clock.tick(1);
@@ -36,7 +35,7 @@ test.skip('it updates changed state', t => {
     t.true(spy.withArgs('persist:persist-reducer-test', '{"a":"2"}').calledOnce);
 })
 
-test.skip('it does not update unchanged state', t => {
+test.serial('it does not update unchanged state', t => {
     const { update } = createPersistoid(config)
     update({ a: undefined, b: 1 })
     clock.tick(1);
@@ -47,7 +46,7 @@ test.skip('it does not update unchanged state', t => {
     t.true(spy.withArgs('persist:persist-reducer-test', '{"b":"1"}').calledOnce);
 })
 
-test.skip('it updates removed keys', t => {
+test.serial('it updates removed keys', t => {
     const { update } = createPersistoid(config)
     update({ a: undefined, b: 1 })
     clock.tick(1);


### PR DESCRIPTION
## Summary

- Three tests in `tests/createPersistor.spec.ts` were skipped with a note that they broke after a sinon update
- The root cause was AVA's default concurrent test execution: all three `beforeEach` hooks fired simultaneously and raced to spy on the same shared `memoryStorage` singleton, causing sinon to throw `Attempted to wrap setItem which is already wrapped` on the second and third hooks
- `sinon.useFakeTimers()` is also global state, making concurrent execution unsafe here
- Fix: switch all three from `test.skip` to `test.serial` so AVA runs them sequentially — each `afterEach` fully restores before the next `beforeEach` starts

## Test plan

- [x] All three previously-skipped tests now pass: `it updates changed state`, `it does not update unchanged state`, `it updates removed keys`
- [x] Full test suite passes (25/25)

Generated with [Claude Code](https://claude.com/claude-code)
