### PR TITLE
docs: improve PersistGate.md with definition and props table

### DIFF
--- a/docs/PersistGate.md
+++ b/docs/PersistGate.md
@@ -1,4 +1,13 @@
-`PersistGate` is a React component that delays the rendering of your app's UI until your persisted state has been retrieved and saved to redux. 
+`PersistGate` is a React component that delays the rendering of your app's UI until your persisted state has been retrieved and saved to redux. It acts as a "gate" around your application, allowing you to control when the "gate" will open and what to show users before the "gate" opens. 
+
+## Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `persistor` | `Persistor` | Yes | The persistor instance returned by `persistStore`. `PersistGate` subscribes to this to know when bootstrapping is complete. |
+| `loading` | `ReactNode` | No | A React element to render while the persisted state is loading (e.g. a splash screen). Defaults to `null`. |
+| `children` | `ReactNode \| (bootstrapped: boolean) => ReactNode` | No | Your app's UI. Can also be a render function that receives a `bootstrapped` boolean, useful when you need to handle the loading state inline. Defaults to `null`. |
+| `onBeforeLift` | `() => void` | No | A callback invoked just before the gate lifts (i.e. just before `bootstrapped` becomes `true`). Supports returning a `Promise` to delay lifting until async work completes. |
 
 **NOTE**: the `loading` prop can be `null` or any react instance to show during loading (e.g. a splash screen), for example `loading={<Loading />}`.
 

--- a/docs/PersistGate.md
+++ b/docs/PersistGate.md
@@ -1,4 +1,4 @@
-`PersistGate` is a React component that acts as a render gate between your Redux store and your app's UI. `PersistGate` delays the rendering of your app's UI until your persisted state has been retrieved and saved to redux.
+`PersistGate` is a React component that delays the rendering of your app's UI until your persisted state has been retrieved and saved to redux. 
 
 **NOTE**: the `loading` prop can be `null` or any react instance to show during loading (e.g. a splash screen), for example `loading={<Loading />}`.
 

--- a/docs/PersistGate.md
+++ b/docs/PersistGate.md
@@ -1,4 +1,4 @@
-`PersistGate` delays the rendering of your app's UI until your persisted state has been retrieved and saved to redux.
+`PersistGate` is a React component that acts as a render gate between your Redux store and your app's UI. `PersistGate` delays the rendering of your app's UI until your persisted state has been retrieved and saved to redux.
 
 **NOTE**: the `loading` prop can be `null` or any react instance to show during loading (e.g. a splash screen), for example `loading={<Loading />}`.
 


### PR DESCRIPTION
## Summary

- Adds a clearer opening sentence to `docs/PersistGate.md` explaining what `PersistGate` is and how the "gate" metaphor works
- Adds a props table documenting all four props: `persistor`, `loading`, `children`, and `onBeforeLift`

## Test plan

- [ ] Review `docs/PersistGate.md` for accuracy and clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)