### PR TITLE
Adds failing unit test to surface issue with Noop storage 

### DIFF
--- a/src/storage/getStorage.ts
+++ b/src/storage/getStorage.ts
@@ -1,6 +1,7 @@
 import type { Storage } from '../types'
 
 const noop = (): void => undefined
+
 const noopStorage = {
   getItem: noop,
   setItem: noop,
@@ -9,7 +10,7 @@ const noopStorage = {
   getAllKeys: noop,
 }
 
-function hasStorage(storageType: string) {
+function hasStorage(storageType: string): boolean {
   if (typeof self !== 'object' || !(storageType in self)) {
     return false
   }

--- a/tests/getStorage.spec.ts
+++ b/tests/getStorage.spec.ts
@@ -1,0 +1,21 @@
+import test from 'ava'
+import getStorage from '../src/storage/getStorage'
+
+
+test('getStorage returns noopStorage when storageType does not have a support storage engine', (t) => {
+    let storage = getStorage('')
+    let actualNoopReturnValue = storage.getItem("")
+    let expectedValue = undefined
+
+    t.truthy(storage)
+    t.is(actualNoopReturnValue, expectedValue)
+})
+
+// TODO: This test purposely fails. Resolve underlying issue.
+test('getStorage methods will error out when trying to call a .then statement on a noop', (t) => {
+    let storage = getStorage('')
+
+    let errorOut = storage.getItem("").then(() =>
+        console.log("this console.log shouldn't run. An error should be thrown by the .then() statement. ")
+    )
+})


### PR DESCRIPTION
This PR adds a spec file for `getStorage.ts` and two unit tests. The second unit test purposely fails to surface the issue with the current noopStorage implementation noted in issue #52. 

Will fix the issue in a later PR. I just want to get this PR in to surface the issue and to make sure it gets worked on transparently. I believe the fix is as simple as changing the return type of noop from `void` to `Promise.resolve(null)`, but I just want to double check first. 