### PR TITLE
fix: noopStorage methods return Promise to prevent crash when localStorage unavailable

### DIFF
--- a/src/storage/getStorage.ts
+++ b/src/storage/getStorage.ts
@@ -1,6 +1,6 @@
 import type { Storage } from '../types'
 
-const noop = (): void => undefined
+const noop = (): Promise<null> => Promise.resolve(null)
 
 const noopStorage = {
   getItem: noop,

--- a/tests/getStorage.spec.ts
+++ b/tests/getStorage.spec.ts
@@ -4,18 +4,12 @@ import getStorage from '../src/storage/getStorage'
 
 test('getStorage returns noopStorage when storageType does not have a support storage engine', (t) => {
     let storage = getStorage('')
-    let actualNoopReturnValue = storage.getItem("")
-    let expectedValue = undefined
-
     t.truthy(storage)
-    t.is(actualNoopReturnValue, expectedValue)
 })
 
-// TODO: This test purposely fails. Resolve underlying issue.
-test('getStorage methods will error out when trying to call a .then statement on a noop', (t) => {
+test('getStorage noop methods return a Promise so callers can chain .then() without crashing', async (t) => {
     let storage = getStorage('')
 
-    let errorOut = storage.getItem("").then(() =>
-        console.log("this console.log shouldn't run. An error should be thrown by the .then() statement. ")
-    )
+    const result = await storage.getItem('').then(() => 'resolved')
+    t.is(result, 'resolved')
 })


### PR DESCRIPTION
## Summary

Fixes #52.

- Changed `noop` in `src/storage/getStorage.ts` from `(): void => undefined` to `(): Promise<null> => Promise.resolve(null)`
- All five `noopStorage` methods (`getItem`, `setItem`, `removeItem`, `getAllKeys`) now return a resolved Promise instead of `undefined`
- Updated `tests/getStorage.spec.ts`: removed the intentionally-failing test from PR #53 and replaced it with a passing async test that verifies `.then()` chaining works on noop methods

## Why

Callers in `getStoredState.ts` and `createPersistoid.ts` call `.then()` and `.catch()` on storage method return values. When `localStorage` is unavailable (SSR, strict private browsing), `getStorage` falls back to `noopStorage`, and calling `.then()` on `undefined` throws `Cannot read property 'then' of undefined`.

## Test plan

- [ ] `npx ava tests/getStorage.spec.ts` — both tests pass
- [ ] `npm test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)