### PR TITLE
Fix and Improve throttle behavior in createPersistoid

### DIFF
--- a/src/createPersistoid.ts
+++ b/src/createPersistoid.ts
@@ -50,12 +50,15 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
       }
     })
 
-    // start the time iterator if not running (read: throttle)
-    if (timeIterator === null) {
+    lastState = state
+
+    if (!throttle) {
+      while (keysToProcess.length) {
+        processNextKey()
+      }
+    } else if (timeIterator === null) {
       timeIterator = setInterval(processNextKey, throttle)
     }
-
-    lastState = state
   }
 
   function processNextKey() {

--- a/src/createPersistoid.ts
+++ b/src/createPersistoid.ts
@@ -25,7 +25,7 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
   let lastState: KeyAccessState = {}
   const stagedState: KeyAccessState = {}
   const keysToProcess: string[] = []
-  let timeIterator: any = null
+  let writeTimeout: any = null
   let writePromise: Promise<any> | null = null
 
   const update = (state: KeyAccessState) => {
@@ -56,15 +56,13 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
       while (keysToProcess.length) {
         processNextKey()
       }
-    } else if (timeIterator === null) {
-      timeIterator = setInterval(processNextKey, throttle)
+    } else if (writeTimeout === null) {
+      writeTimeout = setTimeout(flush, throttle)
     }
   }
 
   function processNextKey() {
     if (keysToProcess.length === 0) {
-      if (timeIterator) clearInterval(timeIterator)
-      timeIterator = null
       return
     }
 
@@ -138,9 +136,13 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
     }
   }
 
-  const flush = () => {
+  function flush() {
     while (keysToProcess.length !== 0) {
       processNextKey()
+    }
+    if (writeTimeout) {
+      clearTimeout(writeTimeout)
+      writeTimeout = null
     }
     return writePromise || Promise.resolve()
   }

--- a/tests/throttleIssues.spec.ts
+++ b/tests/throttleIssues.spec.ts
@@ -18,67 +18,54 @@ test.afterEach(() => {
   clock.restore()
 })
 
-// Issue #720: Total write time multiplies by the number of changed keys.
+// Issue #720: Total write time must not multiply by the number of changed keys.
 // With N keys and throttle T, write time should be ~T ms, not N × T ms.
-// This test purposely fails to surface the bug. Will address in a later PR.
 test.serial(
-  'FAILING: write time grows with key count — 3 changed keys at throttle=100ms should produce one write within 100ms, not after 3×100ms=300ms (issue #720)',
+  'write time grows with key count — 3 changed keys at throttle=100ms should produce one write within 100ms, not after 3×100ms=300ms (issue #720)',
   (t) => {
     const { update } = createPersistoid({ key: 'test', version: 1, storage: memoryStorage, throttle: 100 })
     update({ a: 1, b: 2, c: 3 })
 
-    // Advance exactly one throttle interval. The correct behavior is for all 3 keys
-    // to be batched and written in this single interval.
+    // Advance exactly one throttle interval. All 3 keys are batched and written
+    // in this single timeout via flush().
     clock.tick(100)
 
-    // BUG: only key 'a' has been processed so far; 'b' and 'c' are still queued.
-    // writeStagedState() is not called until the queue empties, which requires 3 ticks
-    // (300ms total). So storage.setItem has not been called yet.
     t.true(spy.calledOnce)
   }
 )
 
-// Issue #888: setInterval(fn, 0) is asynchronous even when throttle=0.
+// Issue #888: throttle=0 writes must be synchronous.
 // In a beforeunload handler the browser closes the tab before any queued callbacks
-// fire, so state dispatched just before tab close is silently lost.
-// This test purposely fails to surface the bug. Will address in a later PR.
+// fire, so state dispatched just before tab close is silently lost if writes are async.
 test.serial(
-  'FAILING: throttle=0 writes are not synchronous — state is lost if the event loop does not advance (issue #888)',
+  'throttle=0 writes are synchronous — state is not lost if the event loop does not advance (issue #888)',
   (t) => {
     const { update } = createPersistoid({ key: 'test', version: 1, storage: memoryStorage, throttle: 0 })
     update({ a: 1 })
 
-    // No clock advancement here. If writes were synchronous (the intended behaviour
-    // of throttle=0), storage.setItem would already have been called. But because the
-    // implementation uses setInterval(fn, 0), the callback is always async: it will
-    // not fire until the next event loop turn, which never comes during beforeunload.
-    // BUG: setItem has not been called.
+    // No clock advancement. Because throttle=0 processes keys synchronously inside
+    // update(), storage.setItem is called immediately without waiting for the event loop.
     t.true(spy.calledOnce)
   }
 )
 
-// Issue #1171: Rapid state updates can starve the write queue indefinitely.
-// Because only one key is processed per throttle tick, new updates can re-queue
-// the just-processed key before the queue empties, keeping keysToProcess.length > 0
-// forever and preventing writeStagedState() from ever being called.
-// This test purposely fails to surface the bug. Will address in a later PR.
+// Issue #1171: Rapid state updates must not starve the write queue indefinitely.
+// Previously, only one key was processed per throttle tick, so new updates could
+// re-queue the just-processed key before the queue emptied, preventing any write.
 test.serial(
-  'FAILING: rapid updates starve the write queue — storage.setItem is never called when updates continuously re-queue keys (issue #1171)',
+  'rapid updates do not starve the write queue — storage.setItem is called even when updates continuously re-queue keys (issue #1171)',
   (t) => {
     const { update } = createPersistoid({ key: 'test', version: 1, storage: memoryStorage, throttle: 100 })
     update({ a: 1, b: 2, c: 3, d: 4, e: 5 })
 
-    // Each clock.tick(100) fires processNextKey() once, removing one key from the queue.
-    // The subsequent update() call changes all 5 values, re-queuing the key that was
-    // just removed. The queue stays at length 5 and writeStagedState() is never reached.
+    // Each clock.tick(100) fires flush() which processes all queued keys at once,
+    // then a new update() re-queues changed keys for the next timeout.
     for (let i = 0; i < 5; i++) {
       clock.tick(100)
       update({ a: i + 2, b: i + 3, c: i + 4, d: i + 5, e: i + 6 })
     }
 
-    // After 5 throttle intervals (500ms) we expect at least one write to storage.
-    // BUG: the queue never empties, so writeStagedState() is never called and
-    // storage.setItem is never invoked.
+    // After 5 throttle intervals (500ms) at least one write to storage must have occurred.
     t.true(spy.called)
   }
 )

--- a/tests/throttleIssues.spec.ts
+++ b/tests/throttleIssues.spec.ts
@@ -1,0 +1,84 @@
+import test from 'ava'
+import sinon from 'sinon'
+import createMemoryStorage from './utils/createMemoryStorage'
+import createPersistoid from '../src/createPersistoid'
+
+let memoryStorage: ReturnType<typeof createMemoryStorage>
+let spy: sinon.SinonSpy
+let clock: sinon.SinonFakeTimers
+
+test.beforeEach(() => {
+  memoryStorage = createMemoryStorage()
+  spy = sinon.spy(memoryStorage, 'setItem')
+  clock = sinon.useFakeTimers()
+})
+
+test.afterEach(() => {
+  spy.restore()
+  clock.restore()
+})
+
+// Issue #720: Total write time multiplies by the number of changed keys.
+// With N keys and throttle T, write time should be ~T ms, not N × T ms.
+// This test purposely fails to surface the bug. Will address in a later PR.
+test.serial(
+  'FAILING: write time grows with key count — 3 changed keys at throttle=100ms should produce one write within 100ms, not after 3×100ms=300ms (issue #720)',
+  (t) => {
+    const { update } = createPersistoid({ key: 'test', version: 1, storage: memoryStorage, throttle: 100 })
+    update({ a: 1, b: 2, c: 3 })
+
+    // Advance exactly one throttle interval. The correct behavior is for all 3 keys
+    // to be batched and written in this single interval.
+    clock.tick(100)
+
+    // BUG: only key 'a' has been processed so far; 'b' and 'c' are still queued.
+    // writeStagedState() is not called until the queue empties, which requires 3 ticks
+    // (300ms total). So storage.setItem has not been called yet.
+    t.true(spy.calledOnce)
+  }
+)
+
+// Issue #888: setInterval(fn, 0) is asynchronous even when throttle=0.
+// In a beforeunload handler the browser closes the tab before any queued callbacks
+// fire, so state dispatched just before tab close is silently lost.
+// This test purposely fails to surface the bug. Will address in a later PR.
+test.serial(
+  'FAILING: throttle=0 writes are not synchronous — state is lost if the event loop does not advance (issue #888)',
+  (t) => {
+    const { update } = createPersistoid({ key: 'test', version: 1, storage: memoryStorage, throttle: 0 })
+    update({ a: 1 })
+
+    // No clock advancement here. If writes were synchronous (the intended behaviour
+    // of throttle=0), storage.setItem would already have been called. But because the
+    // implementation uses setInterval(fn, 0), the callback is always async: it will
+    // not fire until the next event loop turn, which never comes during beforeunload.
+    // BUG: setItem has not been called.
+    t.true(spy.calledOnce)
+  }
+)
+
+// Issue #1171: Rapid state updates can starve the write queue indefinitely.
+// Because only one key is processed per throttle tick, new updates can re-queue
+// the just-processed key before the queue empties, keeping keysToProcess.length > 0
+// forever and preventing writeStagedState() from ever being called.
+// This test purposely fails to surface the bug. Will address in a later PR.
+test.serial(
+  'FAILING: rapid updates starve the write queue — storage.setItem is never called when updates continuously re-queue keys (issue #1171)',
+  (t) => {
+    const { update } = createPersistoid({ key: 'test', version: 1, storage: memoryStorage, throttle: 100 })
+    update({ a: 1, b: 2, c: 3, d: 4, e: 5 })
+
+    // Each clock.tick(100) fires processNextKey() once, removing one key from the queue.
+    // The subsequent update() call changes all 5 values, re-queuing the key that was
+    // just removed. The queue stays at length 5 and writeStagedState() is never reached.
+    for (let i = 0; i < 5; i++) {
+      clock.tick(100)
+      update({ a: i + 2, b: i + 3, c: i + 4, d: i + 5, e: i + 6 })
+    }
+
+    // After 5 throttle intervals (500ms) we expect at least one write to storage.
+    // BUG: the queue never empties, so writeStagedState() is never called and
+    // storage.setItem is never invoked.
+    t.true(spy.called)
+  }
+)


### PR DESCRIPTION
## Summary

This addresses the throttle issues tracked in #4. Contributions welcome — see the open items below.

- Adds unit tests that surface all three throttle bugs (issues #720, #888, #1171) described in #4
- Fixes bug #888: when throttle=0, keys are now processed synchronously inside update() so state is not lost during beforeunload handlers (browser) or background execution (React Native)
- Fixes bug #720 by changing from using a setInterval method to using a setTimeout method. The desired effect is that now createPersistoid will throttle once per write to storage rather than throttle on each individual key value change as it was doing previously.

## What the underlying issues were:

- **#888** - keys should get processed synchronously when throttle = 0, so that state doesn't get lost in certain situations noted in the issues linked to above. 
- **#720** - write time multiplies with key count: with N changed keys and throttle T ms, the total write time is N x T ms instead of ~T ms, because processNextKey handles one key per interval tick
- **#1171** - Rapid state updates must not starve the write queue indefinitely.


## Test plan

- Added three unit tests to surface the bugs mentioned.