### PR TITLE
feat: thread PreloadedState type param through persistReducer

### DIFF
--- a/src/persistReducer.ts
+++ b/src/persistReducer.ts
@@ -1,4 +1,4 @@
-import { Action, AnyAction, Reducer } from 'redux'
+import { Action } from 'redux'
 
 import { FLUSH, PAUSE, PERSIST, PURGE, REHYDRATE, DEFAULT_VERSION } from './constants'
 
@@ -9,13 +9,17 @@ import createPersistoid from './createPersistoid'
 import defaultGetStoredState from './getStoredState'
 import purgeStoredState from './purgeStoredState'
 
-type PersistPartial = { _persist: PersistState } | any
+type ReducerWithPreloadedState<S, A extends Action, P = S> = (
+  state: S | P | undefined,
+  action: A
+) => S
+
 const DEFAULT_TIMEOUT = 5000
 
-export default function persistReducer<S extends KeyAccessState, A extends Action>(
+export default function persistReducer<S extends KeyAccessState, A extends Action, P = S>(
   config: PersistConfig<S>,
-  baseReducer: Reducer<S, A>
-): Reducer<S & PersistPartial, AnyAction> {
+  baseReducer: ReducerWithPreloadedState<S, A, P>
+): ReducerWithPreloadedState<S & { _persist: PersistState }, A, P & { _persist?: PersistState }> {
   if (process.env.NODE_ENV !== 'production') {
     if (!config) throw new Error('config is required for persistReducer')
     if (!config.key) throw new Error('key is required in persistor config')


### PR DESCRIPTION
## Summary

- Adds a third generic `P = S` to `persistReducer` so the `PreloadedState` type parameter introduced in Redux v5 is preserved, rather than collapsed into the ongoing state type `S`
- Uses a local structural type (`ReducerWithPreloadedState`) instead of Redux's `Reducer<S, A, P>` to remain compatible with Redux v4 users
- Tightens the previously loose `PersistPartial = { _persist: PersistState } | any` (which was effectively `any`) into an explicit return type

Closes the type compatibility portion of #45.

## Before / After

**Before:**
```ts
function persistReducer<S, A extends Action>(
  config: PersistConfig<S>,
  baseReducer: Reducer<S, A>
): Reducer<S & PersistPartial, AnyAction>
```

**After:**
```ts
function persistReducer<S, A extends Action, P = S>(
  config: PersistConfig<S>,
  baseReducer: (state: S | P | undefined, action: A) => S
): (state: (S & { _persist: PersistState }) | (P & { _persist?: PersistState }) | undefined, action: A) => S & { _persist: PersistState }
```

## Test plan

- [x] All 35 existing tests pass (`npm test`)
- [ ] Manually verify with a Redux v5 + RTK v2 project using `preloadedState`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
