### PR TITLE
feat: add createFilesystemStorage adapter for react-native-blob-util

### DIFF
--- a/src/storage/createFilesystemStorage.ts
+++ b/src/storage/createFilesystemStorage.ts
@@ -1,18 +1,4 @@
-export interface FilesystemStorageOptions {
-  storagePath: string
-  encoding: string
-  toFileName: (name: string) => string
-  fromFileName: (name: string) => string
-}
-
-export interface FilesystemStorage {
-  config: (customOptions: Partial<FilesystemStorageOptions>) => void
-  setItem: (key: string, value: string, callback?: (error?: Error | null) => void) => Promise<void>
-  getItem: (key: string, callback?: (error?: Error | null, result?: string | null) => void) => Promise<string | null | undefined>
-  removeItem: (key: string, callback?: (error?: Error | null) => void) => Promise<undefined>
-  getAllKeys: (callback?: (error?: Error | null, keys?: Array<string>) => any) => Promise<string[] | undefined>
-  clear: (callback?: (error?: Error | null, allKeysCleared?: boolean) => void) => Promise<boolean>
-}
+import type { FilesystemStorageOptions, FilesystemStorage } from '../types'
 
 export default function createFilesystemStorage(ReactNativeBlobUtil: any): FilesystemStorage {
   const createStoragePathIfNeeded = (path: string): Promise<any> =>
@@ -136,34 +122,25 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
         }),
 
     clear: (callback?: (error?: Error | null, allKeysCleared?: boolean) => void) =>
-      storage.getAllKeys((error, keys) => {
-        if (error) throw error
-
-        if (Array.isArray(keys) && keys.length) {
-          const removedKeys: string[] = []
-
-          keys.forEach((key) => {
-            storage.removeItem(key, (error?: Error | null) => {
-              removedKeys.push(key)
-              if (error && callback) {
-                callback(error, false)
-              }
-              if (removedKeys.length === keys.length && callback) {
-                callback(null, true)
-              }
+      storage
+        .getAllKeys()
+        .then((keys) => {
+          if (Array.isArray(keys) && keys.length) {
+            return Promise.all(keys.map((key) => storage.removeItem(key))).then(() => {
+              callback?.(null, true)
+              return true
             })
-          })
-          return true
-        }
-
-        callback?.(null, false)
-        return false
-      }).catch((error: Error) => {
-        if (!callback) {
-          throw error
-        }
-        callback(error)
-      }),
+          }
+          callback?.(null, false)
+          return false
+        })
+        .catch((error: Error) => {
+          if (!callback) {
+            throw error
+          }
+          callback(error)
+          return false
+        })
   }
 
   return storage

--- a/src/storage/createFilesystemStorage.ts
+++ b/src/storage/createFilesystemStorage.ts
@@ -1,0 +1,165 @@
+export interface FilesystemStorageOptions {
+  storagePath: string
+  encoding: string
+  toFileName: (name: string) => string
+  fromFileName: (name: string) => string
+}
+
+export interface FilesystemStorage {
+  config: (customOptions: Partial<FilesystemStorageOptions>) => void
+  setItem: (key: string, value: string, callback?: (error?: Error | null) => void) => Promise<void>
+  getItem: (key: string, callback?: (error?: Error | null, result?: string | null) => void) => Promise<string | null | undefined>
+  removeItem: (key: string, callback?: (error?: Error | null) => void) => Promise<undefined>
+  getAllKeys: (callback?: (error?: Error | null, keys?: Array<string>) => any) => Promise<string[] | undefined>
+  clear: (callback?: (error?: Error | null, allKeysCleared?: boolean) => void) => Promise<boolean>
+}
+
+export default function createFilesystemStorage(ReactNativeBlobUtil: any): FilesystemStorage {
+  const createStoragePathIfNeeded = (path: string): Promise<any> =>
+    ReactNativeBlobUtil.fs
+      .exists(path)
+      .then((exists: boolean) =>
+        exists ? Promise.resolve(true) : ReactNativeBlobUtil.fs.mkdir(path)
+      )
+
+  const onStorageReadyFactory =
+    (storagePath: string) =>
+    (func: Function) => {
+      const storage = createStoragePathIfNeeded(storagePath)
+      return (...args: Array<any>) => storage.then(() => func(...args))
+    }
+
+  const defaultStoragePath = `${ReactNativeBlobUtil.fs.dirs.DocumentDir}/persistStore`
+
+  let onStorageReady = onStorageReadyFactory(defaultStoragePath)
+  let options: FilesystemStorageOptions = {
+    storagePath: defaultStoragePath,
+    encoding: 'utf8',
+    toFileName: (name: string) => name.split(':').join('-'),
+    fromFileName: (name: string) => name.split('-').join(':'),
+  }
+
+  const pathForKey = (key: string) => `${options.storagePath}/${options.toFileName(key)}`
+
+  const storage: FilesystemStorage = {
+    config: (customOptions: Partial<FilesystemStorageOptions>) => {
+      options = {
+        ...options,
+        ...customOptions,
+      }
+      onStorageReady = onStorageReadyFactory(options.storagePath)
+    },
+
+    setItem: (key: string, value: string, callback?: (error?: Error | null) => void) =>
+      ReactNativeBlobUtil.fs
+        .writeFile(pathForKey(key), value, options.encoding)
+        .then(() => callback && callback())
+        .catch((error: Error) => callback && callback(error)),
+
+    getItem: onStorageReady(
+      (key: string, callback?: (error?: Error | null, result?: string | null) => void) => {
+        const filePath = pathForKey(options.toFileName(key))
+
+        return ReactNativeBlobUtil.fs
+          .readFile(filePath, options.encoding)
+          .then((data: string) => {
+            if (!callback) {
+              return data
+            }
+            callback(null, data)
+          })
+          .catch((err: Error) =>
+            ReactNativeBlobUtil.fs.exists(filePath).then((exists: boolean) => {
+              if (!exists) {
+                return null
+              }
+              if (!callback) {
+                throw err
+              }
+              callback(err)
+            })
+          )
+      }
+    ),
+
+    removeItem: (key: string, callback?: (error?: Error | null) => void) => {
+      const filePath = pathForKey(options.toFileName(key))
+
+      const handleError = (err: Error) => {
+        if (!callback) {
+          throw err
+        }
+        callback(err)
+      }
+
+      return ReactNativeBlobUtil.fs
+        .exists(filePath)
+        .then((exists: boolean) => {
+          if (!exists) {
+            return undefined
+          }
+          return ReactNativeBlobUtil.fs
+            .unlink(filePath)
+            .then(() => callback && callback())
+            .catch(handleError)
+        })
+        .catch(handleError)
+    },
+
+    getAllKeys: (callback?: (error?: Error | null, keys?: Array<string>) => any) =>
+      ReactNativeBlobUtil.fs
+        .exists(options.storagePath)
+        .then((exists: boolean) =>
+          exists ? true : ReactNativeBlobUtil.fs.mkdir(options.storagePath)
+        )
+        .then(() =>
+          ReactNativeBlobUtil.fs
+            .ls(options.storagePath)
+            .then((files: string[]) => files.map((file) => options.fromFileName(file)))
+            .then((files: string[]) => {
+              callback && callback(null, files)
+              if (!callback) {
+                return files
+              }
+            })
+        )
+        .catch((error: Error) => {
+          callback && callback(error)
+          if (!callback) {
+            throw error
+          }
+        }),
+
+    clear: (callback?: (error?: Error | null, allKeysCleared?: boolean) => void) =>
+      storage.getAllKeys((error, keys) => {
+        if (error) throw error
+
+        if (Array.isArray(keys) && keys.length) {
+          const removedKeys: string[] = []
+
+          keys.forEach((key) => {
+            storage.removeItem(key, (error?: Error | null) => {
+              removedKeys.push(key)
+              if (error && callback) {
+                callback(error, false)
+              }
+              if (removedKeys.length === keys.length && callback) {
+                callback(null, true)
+              }
+            })
+          })
+          return true
+        }
+
+        callback && callback(null, false)
+        return false
+      }).catch((error: Error) => {
+        callback && callback(error)
+        if (!callback) {
+          throw error
+        }
+      }),
+  }
+
+  return storage
+}

--- a/src/storage/createFilesystemStorage.ts
+++ b/src/storage/createFilesystemStorage.ts
@@ -54,7 +54,12 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
       ReactNativeBlobUtil.fs
         .writeFile(pathForKey(key), value, options.encoding)
         .then(() => callback && callback())
-        .catch((error: Error) => callback && callback(error)),
+        .catch((error: Error) => {
+          if (!callback) {
+            throw error
+          }
+          callback(error)
+        }),
 
     getItem: onStorageReady(
       (key: string, callback?: (error?: Error | null, result?: string | null) => void) => {
@@ -117,17 +122,17 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
             .ls(options.storagePath)
             .then((files: string[]) => files.map((file) => options.fromFileName(file)))
             .then((files: string[]) => {
-              callback && callback(null, files)
               if (!callback) {
                 return files
               }
+              callback(null, files)
             })
         )
         .catch((error: Error) => {
-          callback && callback(error)
           if (!callback) {
             throw error
           }
+          callback(error)
         }),
 
     clear: (callback?: (error?: Error | null, allKeysCleared?: boolean) => void) =>
@@ -151,13 +156,13 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
           return true
         }
 
-        callback && callback(null, false)
+        callback?.(null, false)
         return false
       }).catch((error: Error) => {
-        callback && callback(error)
         if (!callback) {
           throw error
         }
+        callback(error)
       }),
   }
 

--- a/src/storage/createFilesystemStorage.ts
+++ b/src/storage/createFilesystemStorage.ts
@@ -35,8 +35,8 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
   let options: FilesystemStorageOptions = {
     storagePath: defaultStoragePath,
     encoding: 'utf8',
-    toFileName: (name: string) => name.split(':').join('-'),
-    fromFileName: (name: string) => name.split('-').join(':'),
+    toFileName: (name: string) => encodeURIComponent(name),
+    fromFileName: (name: string) => decodeURIComponent(name),
   }
 
   const pathForKey = (key: string) => `${options.storagePath}/${options.toFileName(key)}`
@@ -63,7 +63,7 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
 
     getItem: onStorageReady(
       (key: string, callback?: (error?: Error | null, result?: string | null) => void) => {
-        const filePath = pathForKey(options.toFileName(key))
+        const filePath = pathForKey(key)
 
         return ReactNativeBlobUtil.fs
           .readFile(filePath, options.encoding)
@@ -88,7 +88,7 @@ export default function createFilesystemStorage(ReactNativeBlobUtil: any): Files
     ),
 
     removeItem: (key: string, callback?: (error?: Error | null) => void) => {
-      const filePath = pathForKey(options.toFileName(key))
+      const filePath = pathForKey(key)
 
       const handleError = (err: Error) => {
         if (!callback) {

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,3 +1,5 @@
 import createWebStorage from './createWebStorage'
+export { default as createFilesystemStorage } from './createFilesystemStorage'
+export type { FilesystemStorage, FilesystemStorageOptions } from './createFilesystemStorage'
 
 export default createWebStorage('local')

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,3 +147,19 @@ export interface Persistor {
   getState(): PersistorState
   subscribe(callback: PersistorSubscribeCallback): () => any
 }
+
+export interface FilesystemStorageOptions {
+  storagePath: string
+  encoding: string
+  toFileName: (name: string) => string
+  fromFileName: (name: string) => string
+}
+
+export interface FilesystemStorage {
+  config: (customOptions: Partial<FilesystemStorageOptions>) => void
+  setItem: (key: string, value: string, callback?: (error?: Error | null) => void) => Promise<void>
+  getItem: (key: string, callback?: (error?: Error | null, result?: string | null) => void) => Promise<string | null | undefined>
+  removeItem: (key: string, callback?: (error?: Error | null) => void) => Promise<undefined>
+  getAllKeys: (callback?: (error?: Error | null, keys?: Array<string>) => any) => Promise<string[] | undefined>
+  clear: (callback?: (error?: Error | null, allKeysCleared?: boolean) => void) => Promise<boolean>
+}

--- a/tests/createFilesystemStorage.spec.ts
+++ b/tests/createFilesystemStorage.spec.ts
@@ -61,6 +61,14 @@ test('setItem writes a value and getItem reads it back', async t => {
   t.is(result, 'my-value')
 })
 
+test('keys containing dashes survive a round-trip from setItem to getItem', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('persist:user-profile', 'data')
+  t.deepEqual(await storage.getAllKeys(), ['persist:user-profile'])
+  t.is(await storage.getItem('persist:user-profile'), 'data')
+})
+
 test('getItem returns null for a key that does not exist', async t => {
   const blob = createMockBlobUtil()
   const storage = createFilesystemStorage(blob)

--- a/tests/createFilesystemStorage.spec.ts
+++ b/tests/createFilesystemStorage.spec.ts
@@ -127,6 +127,17 @@ test('clear removes all stored keys', async t => {
   t.deepEqual(keys, [])
 })
 
+test('clear returns true when all stored keys are successfully removed.', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('x', '1')
+  await storage.setItem('y', '2')
+  const returnValue = await storage.clear()
+  const keys = await storage.getAllKeys()
+  t.deepEqual(keys, [])
+  t.deepEqual(returnValue, true);
+})
+
 test('toFileName and fromFileName transforms are applied to keys', async t => {
   const blob = createMockBlobUtil()
   const storage = createFilesystemStorage(blob)

--- a/tests/createFilesystemStorage.spec.ts
+++ b/tests/createFilesystemStorage.spec.ts
@@ -69,6 +69,15 @@ test('keys containing dashes survive a round-trip from setItem to getItem', asyn
   t.is(await storage.getItem('persist:user-profile'), 'data')
 })
 
+test('custom toFileName is applied exactly once', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('persist:root', 'data')
+  t.is(await storage.getItem('persist:root'), 'data')
+  await storage.removeItem('persist:root')
+  t.is(await storage.getItem('persist:root'), null)
+})
+
 test('getItem returns null for a key that does not exist', async t => {
   const blob = createMockBlobUtil()
   const storage = createFilesystemStorage(blob)

--- a/tests/createFilesystemStorage.spec.ts
+++ b/tests/createFilesystemStorage.spec.ts
@@ -1,0 +1,154 @@
+import test from 'ava'
+import createFilesystemStorage from '../src/storage/createFilesystemStorage'
+
+// In-memory filesystem mock for react-native-blob-util
+function createMockBlobUtil() {
+  const dirs: Record<string, boolean> = { '/mock/documents': true }
+  const files: Record<string, string> = {}
+
+  return {
+    fs: {
+      dirs: {
+        DocumentDir: '/mock/documents',
+      },
+      exists: (path: string) =>
+        Promise.resolve(path in dirs || path in files),
+      mkdir: (path: string) => {
+        dirs[path] = true
+        return Promise.resolve(true)
+      },
+      writeFile: (path: string, value: string, _encoding: string) => {
+        files[path] = value
+        return Promise.resolve()
+      },
+      readFile: (path: string, _encoding: string) => {
+        if (path in files) return Promise.resolve(files[path])
+        return Promise.reject(new Error(`File not found: ${path}`))
+      },
+      unlink: (path: string) => {
+        delete files[path]
+        return Promise.resolve()
+      },
+      ls: (dir: string) => {
+        const prefix = dir + '/'
+        const names = Object.keys(files)
+          .filter(p => p.startsWith(prefix))
+          .map(p => p.slice(prefix.length))
+        return Promise.resolve(names)
+      },
+      _files: files,
+      _dirs: dirs,
+    },
+  }
+}
+
+test('createFilesystemStorage returns a storage object with required methods', t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  t.is(typeof storage.setItem, 'function')
+  t.is(typeof storage.getItem, 'function')
+  t.is(typeof storage.removeItem, 'function')
+  t.is(typeof storage.getAllKeys, 'function')
+  t.is(typeof storage.clear, 'function')
+  t.is(typeof storage.config, 'function')
+})
+
+test('setItem writes a value and getItem reads it back', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('my-key', 'my-value')
+  const result = await storage.getItem('my-key')
+  t.is(result, 'my-value')
+})
+
+test('getItem returns null for a key that does not exist', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  const result = await storage.getItem('nonexistent-key')
+  t.is(result, null)
+})
+
+test('removeItem deletes a stored value', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('delete-me', 'value')
+  await storage.removeItem('delete-me')
+  const result = await storage.getItem('delete-me')
+  t.is(result, null)
+})
+
+test('removeItem is a no-op for a key that does not exist', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await t.notThrowsAsync(() => storage.removeItem('no-such-key'))
+})
+
+test('getAllKeys returns all stored keys', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('a', '1')
+  await storage.setItem('b', '2')
+  await storage.setItem('c', '3')
+  const keys = await storage.getAllKeys()
+  t.deepEqual(keys?.sort(), ['a', 'b', 'c'])
+})
+
+test('getAllKeys returns empty array when no keys exist', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  const keys = await storage.getAllKeys()
+  t.deepEqual(keys, [])
+})
+
+test('clear removes all stored keys', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('x', '1')
+  await storage.setItem('y', '2')
+  await storage.clear()
+  const keys = await storage.getAllKeys()
+  t.deepEqual(keys, [])
+})
+
+test('toFileName and fromFileName transforms are applied to keys', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  // Default transforms: colons become dashes (and vice-versa)
+  await storage.setItem('persist:root', 'data')
+  const keys = await storage.getAllKeys()
+  t.deepEqual(keys, ['persist:root'])
+})
+
+test('config overrides storagePath', async t => {
+  const blob = createMockBlobUtil()
+  blob.fs._dirs['/custom/path'] = true
+  const storage = createFilesystemStorage(blob)
+  storage.config({ storagePath: '/custom/path' })
+  await storage.setItem('cfg-key', 'cfg-value')
+  const result = await storage.getItem('cfg-key')
+  t.is(result, 'cfg-value')
+})
+
+test('setItem calls callback on success', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await new Promise<void>(resolve => {
+    storage.setItem('cb-key', 'cb-val', err => {
+      t.is(err, undefined)
+      resolve()
+    })
+  })
+})
+
+test('getAllKeys calls callback with keys', async t => {
+  const blob = createMockBlobUtil()
+  const storage = createFilesystemStorage(blob)
+  await storage.setItem('k1', 'v1')
+  await new Promise<void>(resolve => {
+    storage.getAllKeys((err, keys) => {
+      t.is(err, null)
+      t.deepEqual(keys, ['k1'])
+      resolve()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This PR implements a storage adapter to use [react-native-blob-util](https://github.com/RonRadtke/react-native-blob-util) with redux-persist.

## Details
- Ports the functionality of [redux-persist-filesystem-storage](https://github.com/robwalkerco/redux-persist-filesystem-storage) directly into the library, closing #64
- Adds `createFilesystemStorage(blobUtil)` — a factory that accepts a `react-native-blob-util` instance, keeping the dependency optional and environment-agnostic
- Implements 5 methods within the factory - `getItem`, `setItem`, `removeItem`, `getAllKeys`, and `clear`
- Exports `createFilesystemStorage`, `FilesystemStorage`, and `FilesystemStorageOptions` from `redux-persist/storage`

## Test plan

- [x] 12 new tests in `tests/createFilesystemStorage.spec.ts` covering `setItem`, `getItem`, `removeItem`, `getAllKeys`, `clear`, `config`, key transforms, and callback APIs
- [x] All 48 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)